### PR TITLE
Transition to `main` default branch

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -8,7 +8,7 @@ about: Create a report to help us improve
 <!--
   Have you read our Code of Conduct?
   By filing an issue or pull request, you are expected to comply with it, including treating everyone with respect:
-  https://github.com/FreeProving/guidelines/blob/master/CODE_OF_CONDUCT.md
+  https://github.com/FreeProving/guidelines/blob/main/CODE_OF_CONDUCT.md
 -->
 
 ### Description

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -8,7 +8,7 @@ about: Suggest an idea for this project
 <!--
   Have you read our Code of Conduct?
   By filing an issue or pull request, you are expected to comply with it, including treating everyone with respect:
-  https://github.com/FreeProving/guidelines/blob/master/CODE_OF_CONDUCT.md
+  https://github.com/FreeProving/guidelines/blob/main/CODE_OF_CONDUCT.md
 -->
 
 ## Description

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -6,9 +6,9 @@ name: CI Pipeline
 # reopened. If just the README or documentation changes, the pipeline does
 # not have to run. It also runs when the workflow configuration changed itself.
 #
-# When such a pull request is merged the resulting `push` event on the master
+# When such a pull request is merged the resulting `push` event on the main
 # branch triggers another run of the CI pipeline. This is necessary because
-# there could be changes to the master branch that are not compatible with the
+# there could be changes to the main branch that are not compatible with the
 # pull request but don't prevent fast-forward merging.
 on:
   pull_request:
@@ -19,7 +19,7 @@ on:
     - '.github/workflows/ci-pipeline.yml'
   push:
     branches:
-    - 'master'
+    - 'main'
     paths:
     - 'cabal.project'
     - 'language-coq.cabal'

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -4,5 +4,5 @@ The Free Proving project and everyone participating in it is governed by our [Co
 By participating, you are expected to uphold this code.
 
 [CODE_OF_CONDUCT]:
-  https://github.com/FreeProving/guidelines/blob/master/CODE_OF_CONDUCT.md
+  https://github.com/FreeProving/guidelines/blob/main/CODE_OF_CONDUCT.md
   "Code of Conduct of the FreeProving project"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,5 +3,5 @@
 See the [contributing guidelines][] of the FreeProving project.
 
 [contributing guidelines]:
-  https://github.com/FreeProving/guidelines/blob/master/CONTRIBUTING.md
+  https://github.com/FreeProving/guidelines/blob/main/CONTRIBUTING.md
   "Contributing Guidelines of the FreeProving project"

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ See the [LICENSE][language-coq/LICENSE] file for details.
   "Free Compiler on GitHub"
 
 [guidelines/CONTRIBUTING]:
-  https://github.com/FreeProving/guidelines/blob/master/CONTRIBUTING.md
+  https://github.com/FreeProving/guidelines/blob/main/CONTRIBUTING.md
   "Contributing Guidelines of the FreeProving project"
 
 [hs-to-coq]:
@@ -71,7 +71,7 @@ See the [LICENSE][language-coq/LICENSE] file for details.
   "hs-to-coq on GitHub"
 
 [language-coq/LICENSE]:
-  https://github.com/FreeProving/language-coq/blob/master/LICENSE
+  https://github.com/FreeProving/language-coq/blob/main/LICENSE
   "haskell-src-transformations — The MIT License"
 
 [software/ghc]:


### PR DESCRIPTION
## Description

We have decided to change the default branch of all repositories in the FreeProving organization from `master` to `main`. See FreeProving/guidelines#2 for more information.

## Tasks

The tasks below have to be completed for the transition to `main` as the new default branch. 

 - [x] Create a new branch `main` from the current `master`.
 - [x] Select `main` as the default branch in the repository settings on GitHub.
 - [x] Add branch protection rules for `main` in the repository settings on GitHub.
 - [x] Change the CI pipeline (if any) to run on pushes to `main`.
 - [x] If there are open pull requests, set their target branch to `main`.
 - [x] Update links to the `master` branch such that they point to `main` instead.
 - [x] Finally, delete the `master` branch. If the repository's `master` branch has been referenced in a published paper, keep the `master` branch, delete all files and commit a README that links to the new default branch.