### PR TITLE
Expand notation definition

### DIFF
--- a/src/lib/Language/Coq/Gallina.hs
+++ b/src/lib/Language/Coq/Gallina.hs
@@ -566,7 +566,7 @@ data Notation
     -- ^ @
     --   Notation "/notation_token/ … /notation_token/" := ( /term/ )
     --     [ ( /syntax_modifier/ , … , /syntax_modifier/ ) ].
-    --   
+    --   @
   | InfixDefinition Op Term (Maybe Associativity) Level
     -- ^ @
     --   Infix "/op/" := ( /term/ )

--- a/src/lib/Language/Coq/Gallina.hs
+++ b/src/lib/Language/Coq/Gallina.hs
@@ -67,6 +67,8 @@ module Language.Coq.Gallina
   , InstanceDefinition(..)
   , Associativity(..)
   , Level(..)
+  , SyntaxModifier(..)
+  , NotationToken(..)
   , Notation(..)
   , NotationBinding(..)
   , Arguments(..)
@@ -527,12 +529,32 @@ data Associativity
 newtype Level = Level Num -- ^ @at level /num/@
  deriving (Eq, Ord, Show, Read)
 
+-- | @/syntax_modifier/ ::=@ /(extra)/
+data SyntaxModifier
+  = SModLevel Level                       -- ^ @/level/@
+  | SModIdentLevel (NonEmpty Ident) Level -- ^ @/ident/ , … , /ident/ /level/@
+  | SModAssociativity Associativity       -- ^ @/associativity/ associativity@
+  | SModOnlyParsing                       -- ^ @only parsing@
+  | SModOnlyPrinting                      -- ^ @only printing@
+ deriving (Eq, Ord, Show, Read)
+
+-- | @/notation_token/ ::=@ /(extra)/
+data NotationToken
+  = NSymbol Text -- ^ @'/text/'@
+  | NIdent Ident -- ^ @/ident/@
+ deriving (Eq, Ord, Show, Read)
+
 -- | @/notation/ ::=@ /(extra)/
 data Notation
   = ReservedNotationIdent Ident
     -- ^ @Reserved Notation "'/ident/'" .@
   | NotationBinding NotationBinding
     -- ^ @Notation /notation_binding/ .@
+  | NotationDefinition (NonEmpty NotationToken) Term [SyntaxModifier]
+    -- ^ @
+    --   Notation "/notation_token/ … /notation_token/" := ( /term/ )
+    --     [ ( /syntax_modifier/ , … , /syntax_modifier/ ) ].
+    --   
   | InfixDefinition Op Term (Maybe Associativity) Level
     -- ^ @
     --   Infix "/op/" := ( /term/ )

--- a/src/lib/Language/Coq/Gallina.hs
+++ b/src/lib/Language/Coq/Gallina.hs
@@ -67,6 +67,7 @@ module Language.Coq.Gallina
   , InstanceDefinition(..)
   , Associativity(..)
   , Level(..)
+  , LevelExplicitOrNext(..)
   , SyntaxModifier(..)
   , NotationToken(..)
   , Notation(..)
@@ -529,13 +530,24 @@ data Associativity
 newtype Level = Level Num -- ^ @at level /num/@
  deriving (Eq, Ord, Show, Read)
 
+-- | @/level_explicit_or_next/ ::=@ /(extra)/
+data LevelExplicitOrNext
+  = ExplicitLevel Level -- ^ @/level/@
+  | NextLevel           -- ^ @at next level@
+ deriving (Eq, Ord, Show, Read)
+
 -- | @/syntax_modifier/ ::=@ /(extra)/
 data SyntaxModifier
-  = SModLevel Level                       -- ^ @/level/@
-  | SModIdentLevel (NonEmpty Ident) Level -- ^ @/ident/ , … , /ident/ /level/@
-  | SModAssociativity Associativity       -- ^ @/associativity/ associativity@
-  | SModOnlyParsing                       -- ^ @only parsing@
-  | SModOnlyPrinting                      -- ^ @only printing@
+  = SModLevel Level
+    -- ^ @/level/@
+  | SModIdentLevel (NonEmpty Ident) LevelExplicitOrNext
+    -- ^ @/ident/ , … , /ident/ /level_explicit_or_next/@
+  | SModAssociativity Associativity
+    -- ^ @/associativity/ associativity@
+  | SModOnlyParsing
+    -- ^ @only parsing@
+  | SModOnlyPrinting
+    -- ^ @only printing@
  deriving (Eq, Ord, Show, Read)
 
 -- | @/notation_token/ ::=@ /(extra)/

--- a/src/lib/Language/Coq/Pretty.hs
+++ b/src/lib/Language/Coq/Pretty.hs
@@ -937,9 +937,9 @@ instance Gallina Notation where
       "Notation" <+> dquotes (foldr (\t' r -> renderGallina t' <+> r) "" ts)
     rhs =
       let term = nest 2 $ parens (renderGallina def)
-      in  case length mods of
-            0 -> term <> "."
-            1 -> term </> parens (renderGallina $ head mods) <> "."
+      in  case mods of
+            []    -> term <> "."
+            [mod] -> term </> parens (renderGallina mod) <> "."
             _ ->
               term
                 <> line

--- a/src/lib/Language/Coq/Pretty.hs
+++ b/src/lib/Language/Coq/Pretty.hs
@@ -907,6 +907,11 @@ instance Gallina Associativity where
 instance Gallina Level where
   renderGallina' _ (Level n) = "at level" <+> renderNum n
 
+instance Gallina LevelExplicitOrNext where
+  renderGallina' _ (ExplicitLevel lvl) = renderGallina lvl
+  renderGallina' _ NextLevel           = "at next level"
+
+
 instance Gallina SyntaxModifier where
   renderGallina' _ (SModLevel lvl) = renderGallina lvl
   renderGallina' _ (SModIdentLevel ids lvl) =

--- a/src/lib/Language/Coq/Pretty.hs
+++ b/src/lib/Language/Coq/Pretty.hs
@@ -911,7 +911,6 @@ instance Gallina LevelExplicitOrNext where
   renderGallina' _ (ExplicitLevel lvl) = renderGallina lvl
   renderGallina' _ NextLevel           = "at next level"
 
-
 instance Gallina SyntaxModifier where
   renderGallina' _ (SModLevel lvl) = renderGallina lvl
   renderGallina' _ (SModIdentLevel ids lvl) =

--- a/src/lib/Language/Coq/Pretty.hs
+++ b/src/lib/Language/Coq/Pretty.hs
@@ -937,7 +937,7 @@ instance Gallina Notation where
     lhs =
       "Notation" <+> dquotes (foldr (\t' r -> renderGallina t' <+> r) "" ts)
     rhs =
-      let term = parens (renderGallina def)
+      let term = nest 2 $ parens (renderGallina def)
       in  case length mods of
             0 -> term <> "."
             1 -> term </> parens (renderGallina $ head mods) <> "."

--- a/src/lib/Language/Coq/Pretty.hs
+++ b/src/lib/Language/Coq/Pretty.hs
@@ -938,8 +938,8 @@ instance Gallina Notation where
     rhs =
       let term = nest 2 $ parens (renderGallina def)
       in  case mods of
-            []    -> term <> "."
-            [mod] -> term </> parens (renderGallina mod) <> "."
+            []     -> term <> "."
+            [smod] -> term </> parens (renderGallina smod) <> "."
             _ ->
               term
                 <> line

--- a/src/lib/Language/Coq/Subst.hs
+++ b/src/lib/Language/Coq/Subst.hs
@@ -146,6 +146,7 @@ instance Subst InstanceDefinition where
 instance Subst Notation where
   subst _f (ReservedNotationIdent _x                ) = error "subst"
   subst _f (NotationBinding       _nb               ) = error "subst"
+  subst _f (NotationDefinition _ts _def _mods       ) = error "subst"
   subst _f (InfixDefinition _op _defn _oassoc _level) = error "subst"
 
 instance Subst NotationBinding where


### PR DESCRIPTION
<!--
  Have you read our Code of Conduct?
  By filing an issue or pull request, you are expected to comply with it, including treating everyone with respect:
  https://github.com/FreeProving/guidelines/blob/main/CODE_OF_CONDUCT.md
-->

### Issue

Closes #3 

### Description of the Change

I added a new constructor for a `Notation`. It takes a nonempty list of notation tokens that specifies the notation string on the left-hand-side of the definition, a term that is bound to the notation and a list of syntax modifiers.
Those notation tokens are either strings that represent a keyword of that notation or an identifier for a variable that can be used on the right-hand-side of the definition.
Supported are the following syntax modifiers.
- Define the parsing level of the whole notation.
- Define the parsing level for a list of variables in the notation.
- Define associativity of the notation.
- Mark the notation as `only parsing` or `only printing`.

### Alternate Designs

The `NotationBinding` constructor could be removed as the notations represented by this are a real subset of the notations represented by the new constructor.

The solution here does not include all syntax modifiers and does also not support scopes for notations ([compare](https://coq.inria.fr/refman/user-extensions/syntax-extensions.html#basic-notations)).
This was done for simplicity reasons.

### Possible Drawbacks

As this is a change to the base language it might cause problems for projects using the current representation.
Those problems are however limited as only one additional constructor and some new data types have been added but no existing constructor has been changed or removed.

I extended the functions `bvOf` and `fvOf` in `Language.Coq.FreeVars` for the new constructor and datatypes but I'm not entirely sure what the result of those functions should be, especially for the new constructor for notations.
I added each identifier, that is a keyword of the notation, to the set of bound variables and used the identifiers for variables as local bound variables when checking the term and syntax modifiers for free variables.

### Verification Process

The code compiles and the notations that I tested were rendered correctly. Examples for constructed notations:
```Coq
Notation "'Nil'" := (pure nil).
```
```Coq
Notation "'Cons' x xs" := (pure
    (cons x xs))
  ( at level 10
  , x, xs at level 9 ).
```
```Coq
Notation "'@Cons' Shape Pos a x xs" :=
  (@pure Shape Pos (List Shape Pos
                         a) (@cons Shape Pos a x xs))
  ( no associativity
  , at level 10
  , Shape
  , Pos
  , a
  , x
  , xs at level 9
  , only parsing ).
```

### Additional Notes
