### PR TITLE
Add `Hint` sentences and `Set`/`Unset` option sentences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.3.0.0 / 2020-08-25
+
+ - **Support hints**
+   + Hint sentences have been added to the Coq AST that support a wide range of hints.
+ - **Support options and flags**
+   + Option sentences have been added to the Coq AST that allow to set and unset arbitrary options and flags.
+
 ## 0.2.0.0 / 2020-08-22
 
  - **Extended notation definitions**

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ In order to use this package in your own project, include the following stanza i
 source-repository-package
   type: git
   location: git://github.com/FreeProving/language-coq.git
-  tag: v0.2.0.0
+  tag: v0.3.0.0
 ```
 
 ## Get Involved

--- a/language-coq.cabal
+++ b/language-coq.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                language-coq
-version:             0.2.0.0
+version:             0.3.0.0
 synopsis:            AST and pretty-printer for Coq
 homepage:            https://github.com/just95/language-coq
 license:             MIT

--- a/src/lib/Language/Coq/FreeVars.hs
+++ b/src/lib/Language/Coq/FreeVars.hs
@@ -9,7 +9,7 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Language.Coq.FreeVars
-  ( -- * Constraint syonyms
+  ( -- * Constraint synonyms
     FreeVars
     -- * Main query functions
   , getFreeVars
@@ -127,6 +127,8 @@ instance HasBV Qualid Sentence where
   bvOf (SectionSentence sec)          = bvOf sec
   bvOf (ArgumentsSentence _arg)       = mempty
   bvOf (CommentSentence com)          = fvOf' com
+  bvOf (HintSentence hint)            = bvOf hint
+  bvOf (OptionSentence _option)       = mempty
 
 instance HasBV Qualid Assumption where
   bvOf (Assumption _kwd assumptions) = bvOf assumptions
@@ -193,6 +195,14 @@ instance HasBV Qualid Notation where
 
 instance HasBV Qualid NotationBinding where
   bvOf (NotationIdentBinding op def) = binder (Bare op) <> fvOf' def
+
+instance HasBV Qualid Hint where
+  bvOf (Hint _locality hint_definition _databases) = bvOf hint_definition
+
+instance HasBV Qualid HintDefinition where
+  bvOf (HintResolve _ _ (Just pattern)) = bvOf pattern
+  bvOf (HintExtern _ (Just pattern) _)  = bvOf pattern
+  bvOf _ = mempty
 
 instance HasBV Qualid LocalModule where
   bvOf (LocalModule _name sentences) = foldTelescope bvOf sentences

--- a/src/lib/Language/Coq/FreeVars.hs
+++ b/src/lib/Language/Coq/FreeVars.hs
@@ -200,8 +200,8 @@ instance HasBV Qualid Hint where
   bvOf (Hint _locality hint_definition _databases) = bvOf hint_definition
 
 instance HasBV Qualid HintDefinition where
-  bvOf (HintResolve _ _ (Just pattern)) = bvOf pattern
-  bvOf (HintExtern _ (Just pattern) _) = bvOf pattern
+  bvOf (HintResolve _ _ (Just pat)) = bvOf pat
+  bvOf (HintExtern _ (Just pat) _) = bvOf pat
   bvOf _ = mempty
 
 instance HasBV Qualid LocalModule where

--- a/src/lib/Language/Coq/FreeVars.hs
+++ b/src/lib/Language/Coq/FreeVars.hs
@@ -201,7 +201,7 @@ instance HasBV Qualid Hint where
 
 instance HasBV Qualid HintDefinition where
   bvOf (HintResolve _ _ (Just pattern)) = bvOf pattern
-  bvOf (HintExtern _ (Just pattern) _)  = bvOf pattern
+  bvOf (HintExtern _ (Just pattern) _) = bvOf pattern
   bvOf _ = mempty
 
 instance HasBV Qualid LocalModule where

--- a/src/lib/Language/Coq/Gallina.hs
+++ b/src/lib/Language/Coq/Gallina.hs
@@ -71,6 +71,13 @@ module Language.Coq.Gallina
   , Arguments(..)
   , ArgumentSpec(..)
   , ArgumentExplicitness(..)
+  , Direction(..)
+  , Transparency(..)
+  , HintDefinition(..)
+  , Hint(..)
+  , SettingName
+  , OptionValue(..)
+  , Option(..)
   ) where
 
 import           Prelude            hiding ( Num )
@@ -359,6 +366,10 @@ data Sentence
     -- ^ @/arguments/@ – extra
   | CommentSentence Comment
     -- ^ @/comment/@ – extra
+  | HintSentence Hint
+    -- ^ @/hint/@ – extra
+  | OptionSentence Option
+    -- ^ @/option/@ – extra
   | LocalModuleSentence LocalModule
   | SectionSentence Section
  deriving ( Eq, Ord, Show, Read )
@@ -591,6 +602,62 @@ data ArgumentExplicitness
   | ArgImplicit -- ^@[ ⋯ ]@ – wrap in square brackets
   | ArgMaximal  -- ^@{ ⋯ }@ – wrap in braces
  deriving ( Eq, Ord, Show, Read, Enum, Bounded )
+
+-- |@/direction/ ::=@ /(extra)/
+data Direction
+  = LeftToRight -- ^@->@
+  | RightToLeft -- ^@<-@
+ deriving ( Eq, Ord, Show, Read )
+
+-- |@/transparency/ ::=@ /(extra)/
+data Transparency
+  = Transparent -- ^@Transparent@
+  | Opaque      -- ^@Opaque@
+ deriving ( Eq, Ord, Show, Read )
+
+-- |@/hint_definition/ ::=@ /(extra)/
+data HintDefinition
+  = HintResolve (NonEmpty Qualid) (Maybe Num) (Maybe Pattern)
+  -- ^@Resolve /qualid/ … /qualid/ [| [/num/] [/pattern/]]@
+  | HintResolveImp Direction (NonEmpty Qualid)
+  -- ^@Resolve /direction/ /qualid/ … /qualid/@
+  | HintImmediate (NonEmpty Qualid)
+  -- ^@Immediate /qualid/ … /qualid/@
+  | HintConstructors (NonEmpty Qualid)
+  -- ^@Constructors /qualid/ … /qualid/@
+  | HintUnfold (NonEmpty Qualid)
+  -- ^@Unfold /qualid/ … /qualid/@
+  | HintTransparency Transparency (NonEmpty Qualid)
+  -- ^@/transparency/ /qualid/ … /qualid/@
+  | HintVariables Transparency
+  -- ^@Variables /transparency/@
+  | HintConstants Transparency
+  -- ^@Constants /transparency/@
+  | HintExtern Num (Maybe Pattern) Tactics
+  -- ^@Extern /num/ [/pattern/] => /tactics/@
+ deriving ( Eq, Ord, Show, Read )
+
+-- |@/hint/ ::=@ /(extra)/
+data Hint
+  = Hint (Maybe Locality) HintDefinition [Ident]
+    -- ^@Hint [/Local/] /hint_definition/ [: /ident/ … /ident/] .@
+ deriving ( Eq, Ord, Show, Read )
+
+type SettingName = Text
+
+-- |@/option_value/ ::=@ /(extra)/
+data OptionValue
+  = OVNum Num   -- ^@/num/@
+  | OVText Text -- ^@/text/@
+ deriving ( Eq, Ord, Show, Read )
+
+-- |@/option/ ::=@ /(extra)/
+data Option
+  = SetOption SettingName (Maybe OptionValue)
+    -- ^@Set /setting_name/ [/option_value/] .@
+  | UnsetOption SettingName
+    -- ^@Unset /setting_name/ .@
+ deriving ( Eq, Ord, Show, Read )
 
 data LocalModule = LocalModule Ident [Sentence]
  deriving ( Eq, Ord, Show, Read )

--- a/src/lib/Language/Coq/Gallina.hs
+++ b/src/lib/Language/Coq/Gallina.hs
@@ -618,29 +618,28 @@ data Transparency
 -- |@/hint_definition/ ::=@ /(extra)/
 data HintDefinition
   = HintResolve (NonEmpty Qualid) (Maybe Num) (Maybe Pattern)
-  -- ^@Resolve /qualid/ … /qualid/ [| [/num/] [/pattern/]]@
+    -- ^@Resolve /qualid/ … /qualid/ [| [/num/] [/pattern/]]@
   | HintResolveImp Direction (NonEmpty Qualid)
-  -- ^@Resolve /direction/ /qualid/ … /qualid/@
+    -- ^@Resolve /direction/ /qualid/ … /qualid/@
   | HintImmediate (NonEmpty Qualid)
-  -- ^@Immediate /qualid/ … /qualid/@
+    -- ^@Immediate /qualid/ … /qualid/@
   | HintConstructors (NonEmpty Qualid)
-  -- ^@Constructors /qualid/ … /qualid/@
+    -- ^@Constructors /qualid/ … /qualid/@
   | HintUnfold (NonEmpty Qualid)
-  -- ^@Unfold /qualid/ … /qualid/@
+    -- ^@Unfold /qualid/ … /qualid/@
   | HintTransparency Transparency (NonEmpty Qualid)
-  -- ^@/transparency/ /qualid/ … /qualid/@
+    -- ^@/transparency/ /qualid/ … /qualid/@
   | HintVariables Transparency
-  -- ^@Variables /transparency/@
+    -- ^@Variables /transparency/@
   | HintConstants Transparency
-  -- ^@Constants /transparency/@
+    -- ^@Constants /transparency/@
   | HintExtern Num (Maybe Pattern) Tactics
-  -- ^@Extern /num/ [/pattern/] => /tactics/@
+    -- ^@Extern /num/ [/pattern/] => /tactics/@
  deriving ( Eq, Ord, Show, Read )
 
 -- |@/hint/ ::=@ /(extra)/
-data Hint
-  = Hint (Maybe Locality) HintDefinition [Ident]
-    -- ^@Hint [/Local/] /hint_definition/ [: /ident/ … /ident/] .@
+data Hint = Hint (Maybe Locality) HintDefinition [Ident]
+  -- ^@Hint [/Local/] /hint_definition/ [: /ident/ … /ident/] .@
  deriving ( Eq, Ord, Show, Read )
 
 type SettingName = Text

--- a/src/lib/Language/Coq/Gallina.hs
+++ b/src/lib/Language/Coq/Gallina.hs
@@ -639,7 +639,7 @@ data HintDefinition
 
 -- |@/hint/ ::=@ /(extra)/
 data Hint = Hint (Maybe Locality) HintDefinition [Ident]
-  -- ^@Hint [/Local/] /hint_definition/ [: /ident/ … /ident/] .@
+  -- ^@[/Local/] Hint /hint_definition/ [: /ident/ … /ident/] .@
  deriving ( Eq, Ord, Show, Read )
 
 type SettingName = Text
@@ -652,10 +652,10 @@ data OptionValue
 
 -- |@/option/ ::=@ /(extra)/
 data Option
-  = SetOption SettingName (Maybe OptionValue)
-    -- ^@Set /setting_name/ [/option_value/] .@
-  | UnsetOption SettingName
-    -- ^@Unset /setting_name/ .@
+  = SetOption (Maybe Locality) SettingName (Maybe OptionValue)
+    -- ^@[/Local/] Set /setting_name/ [/option_value/] .@
+  | UnsetOption (Maybe Locality) SettingName
+    -- ^@[/Local/] Unset /setting_name/ .@
  deriving ( Eq, Ord, Show, Read )
 
 data LocalModule = LocalModule Ident [Sentence]

--- a/src/lib/Language/Coq/Pretty.hs
+++ b/src/lib/Language/Coq/Pretty.hs
@@ -535,6 +535,8 @@ instance Gallina Sentence where
   renderGallina' p (NotationSentence notation)  = renderGallina' p notation
   renderGallina' p (ArgumentsSentence arg)      = renderGallina' p arg
   renderGallina' p (CommentSentence com)        = renderGallina' p com
+  renderGallina' p (HintSentence hint)          = renderGallina' p hint
+  renderGallina' p (OptionSentence opt)         = renderGallina' p opt
   renderGallina' p (LocalModuleSentence lmd)    = renderGallina' p lmd
   renderGallina' p (SectionSentence sec)        = renderGallina' p sec
 
@@ -786,6 +788,59 @@ instance Gallina ArgumentSpec where
             ArgMaximal  -> braces
       in wrap (renderGallina arg)
          <> maybe mempty (("%" <>) . renderIdent) oscope
+
+instance Gallina Direction where
+  renderGallina' _ LeftToRight = "->"
+  renderGallina' _ RightToLeft = "<-"
+
+instance Gallina Transparency where
+  renderGallina' _ Transparent = "Transparent"
+  renderGallina' _ Opaque      = "Opaque"
+
+instance Gallina HintDefinition where
+  renderGallina' _ (HintResolve qualids Nothing Nothing) =
+    "Resolve" <+> foldr (\q r -> renderGallina q <+> r) "" qualids
+  renderGallina' _ (HintResolve qualids mbCost mbPat) =
+    "Resolve" <+> foldr (\q r -> renderGallina q <+> r) "" qualids <+>
+    "|" <+> maybe "" renderNum mbCost <+>
+    maybe "" (renderGallina' 400) mbPat
+  renderGallina' _ (HintResolveImp dir qualids) =
+    "Resolve" <+> renderGallina dir <+>
+    foldr (\q r -> renderGallina q <+> r) "" qualids
+  renderGallina' _ (HintImmediate qualids) =
+    "Immediate" <+> foldr (\q r -> renderGallina q <+> r) "" qualids
+  renderGallina' _ (HintConstructors qualids) =
+    "Constructors" <+> foldr (\q r -> renderGallina q <+> r) "" qualids
+  renderGallina' _ (HintUnfold qualids) =
+    "Unfold" <+> foldr (\q r -> renderGallina q <+> r) "" qualids
+  renderGallina' _ (HintTransparency trans qualids) =
+    renderGallina trans <+> foldr (\q r -> renderGallina q <+> r) "" qualids
+  renderGallina' _ (HintVariables trans) =
+    "Variables" <+> renderGallina trans
+  renderGallina' _ (HintConstants trans) =
+    "Constants" <+> renderGallina trans
+  renderGallina' _ (HintExtern cost mbPat tac) =
+    "Extern" <+> renderNum cost <+> maybe "" (renderGallina' 400) mbPat
+    <+> "=>" <+> text tac
+
+instance Gallina Hint where
+  renderGallina' _ (Hint mbLoc def []) =
+    maybe "" renderGallina mbLoc <+> "Hint" <+> renderGallina def <> "."
+  renderGallina' _ (Hint mbLoc def dbs) =
+    maybe "" renderGallina mbLoc <+> "Hint" <+>  renderGallina def <+> ":" <+>
+    foldr (\db r -> renderIdent db <+> r) "" dbs <> "."
+
+instance Gallina OptionValue where
+  renderGallina' _ (OVNum n) = renderNum n
+  renderGallina' _ (OVText t) = text t
+
+instance Gallina Option where
+  renderGallina' _ (SetOption name Nothing) =
+    "Set" <+> text name <> "."
+  renderGallina' _ (SetOption name (Just opt)) =
+    "Set" <+> text name <+> renderGallina opt <> "."
+  renderGallina' _ (UnsetOption name) =
+    "Unset" <+> text name <> "."
 
 instance Gallina LocalModule where
   renderGallina' _ (LocalModule name sentences) = vcat

--- a/src/lib/Language/Coq/Pretty.hs
+++ b/src/lib/Language/Coq/Pretty.hs
@@ -840,10 +840,15 @@ instance Gallina OptionValue where
   renderGallina' _ (OVText t) = dquotes $ text t
 
 instance Gallina Option where
-  renderGallina' _ (SetOption name Nothing)    = "Set" <+> text name <> "."
-  renderGallina' _ (SetOption name (Just opt))
-    = "Set" <+> text name <+> renderGallina opt <> "."
-  renderGallina' _ (UnsetOption name)          = "Unset" <+> text name <> "."
+  renderGallina' _ (SetOption mbLoc name Nothing)
+    = maybe "" renderGallina mbLoc <+> "Set" <+> text name <> "."
+  renderGallina' _ (SetOption mbLoc name (Just opt)) = maybe "" renderGallina
+    mbLoc
+    <+> "Set"
+    <+> text name
+    <+> renderGallina opt <> "."
+  renderGallina' _ (UnsetOption mbLoc name)
+    = maybe "" renderGallina mbLoc <+> "Unset" <+> text name <> "."
 
 instance Gallina LocalModule where
   renderGallina' _ (LocalModule name sentences) = vcat

--- a/src/lib/Language/Coq/Pretty.hs
+++ b/src/lib/Language/Coq/Pretty.hs
@@ -798,49 +798,52 @@ instance Gallina Transparency where
   renderGallina' _ Opaque      = "Opaque"
 
 instance Gallina HintDefinition where
-  renderGallina' _ (HintResolve qualids Nothing Nothing) =
-    "Resolve" <+> foldr (\q r -> renderGallina q <+> r) "" qualids
-  renderGallina' _ (HintResolve qualids mbCost mbPat) =
-    "Resolve" <+> foldr (\q r -> renderGallina q <+> r) "" qualids <+>
-    "|" <+> maybe "" renderNum mbCost <+>
-    maybe "" (renderGallina' 400) mbPat
-  renderGallina' _ (HintResolveImp dir qualids) =
-    "Resolve" <+> renderGallina dir <+>
-    foldr (\q r -> renderGallina q <+> r) "" qualids
-  renderGallina' _ (HintImmediate qualids) =
-    "Immediate" <+> foldr (\q r -> renderGallina q <+> r) "" qualids
-  renderGallina' _ (HintConstructors qualids) =
-    "Constructors" <+> foldr (\q r -> renderGallina q <+> r) "" qualids
-  renderGallina' _ (HintUnfold qualids) =
-    "Unfold" <+> foldr (\q r -> renderGallina q <+> r) "" qualids
-  renderGallina' _ (HintTransparency trans qualids) =
-    renderGallina trans <+> foldr (\q r -> renderGallina q <+> r) "" qualids
-  renderGallina' _ (HintVariables trans) =
-    "Variables" <+> renderGallina trans
-  renderGallina' _ (HintConstants trans) =
-    "Constants" <+> renderGallina trans
-  renderGallina' _ (HintExtern cost mbPat tac) =
-    "Extern" <+> renderNum cost <+> maybe "" (renderGallina' 400) mbPat
-    <+> "=>" <+> text tac
+  renderGallina' _ (HintResolve qualids Nothing Nothing) = "Resolve"
+    <+> foldr (\q r -> renderGallina q <+> r) "" qualids
+  renderGallina' _ (HintResolve qualids mbCost mbPat)    = "Resolve"
+    <+> foldr (\q r -> renderGallina q <+> r) "" qualids
+    <+> "|"
+    <+> maybe "" renderNum mbCost
+    <+> maybe "" (renderGallina' 400) mbPat
+  renderGallina' _ (HintResolveImp dir qualids)          = "Resolve"
+    <+> renderGallina dir
+    <+> foldr (\q r -> renderGallina q <+> r) "" qualids
+  renderGallina' _ (HintImmediate qualids)               = "Immediate"
+    <+> foldr (\q r -> renderGallina q <+> r) "" qualids
+  renderGallina' _ (HintConstructors qualids)            = "Constructors"
+    <+> foldr (\q r -> renderGallina q <+> r) "" qualids
+  renderGallina' _ (HintUnfold qualids)                  = "Unfold"
+    <+> foldr (\q r -> renderGallina q <+> r) "" qualids
+  renderGallina' _ (HintTransparency trans qualids)      = renderGallina trans
+    <+> foldr (\q r -> renderGallina q <+> r) "" qualids
+  renderGallina' _ (HintVariables trans)
+    = "Variables" <+> renderGallina trans
+  renderGallina' _ (HintConstants trans)
+    = "Constants" <+> renderGallina trans
+  renderGallina' _ (HintExtern cost mbPat tac)           = "Extern"
+    <+> renderNum cost
+    <+> maybe "" (renderGallina' 400) mbPat
+    <+> "=>"
+    <+> text tac
 
 instance Gallina Hint where
-  renderGallina' _ (Hint mbLoc def []) =
-    maybe "" renderGallina mbLoc <+> "Hint" <+> renderGallina def <> "."
-  renderGallina' _ (Hint mbLoc def dbs) =
-    maybe "" renderGallina mbLoc <+> "Hint" <+>  renderGallina def <+> ":" <+>
-    foldr (\db r -> renderIdent db <+> r) "" dbs <> "."
+  renderGallina' _ (Hint mbLoc def [])
+    = maybe "" renderGallina mbLoc <+> "Hint" <+> renderGallina def <> "."
+  renderGallina' _ (Hint mbLoc def dbs) = maybe "" renderGallina mbLoc
+    <+> "Hint"
+    <+> renderGallina def
+    <+> ":"
+    <+> foldr (\db r -> renderIdent db <+> r) "" dbs <> "."
 
 instance Gallina OptionValue where
-  renderGallina' _ (OVNum n) = renderNum n
+  renderGallina' _ (OVNum n)  = renderNum n
   renderGallina' _ (OVText t) = text t
 
 instance Gallina Option where
-  renderGallina' _ (SetOption name Nothing) =
-    "Set" <+> text name <> "."
-  renderGallina' _ (SetOption name (Just opt)) =
-    "Set" <+> text name <+> renderGallina opt <> "."
-  renderGallina' _ (UnsetOption name) =
-    "Unset" <+> text name <> "."
+  renderGallina' _ (SetOption name Nothing)    = "Set" <+> text name <> "."
+  renderGallina' _ (SetOption name (Just opt))
+    = "Set" <+> text name <+> renderGallina opt <> "."
+  renderGallina' _ (UnsetOption name)          = "Unset" <+> text name <> "."
 
 instance Gallina LocalModule where
   renderGallina' _ (LocalModule name sentences) = vcat

--- a/src/lib/Language/Coq/Pretty.hs
+++ b/src/lib/Language/Coq/Pretty.hs
@@ -828,8 +828,8 @@ instance Gallina HintDefinition where
 
 instance Gallina Hint where
   renderGallina' _ (Hint mbLoc def [])
-    = maybe "" renderGallina mbLoc <+> "Hint" <+> renderGallina def <> "."
-  renderGallina' _ (Hint mbLoc def dbs) = maybe "" renderGallina mbLoc
+    = renderFullLocality mbLoc <+> "Hint" <+> renderGallina def <> "."
+  renderGallina' _ (Hint mbLoc def dbs) = renderFullLocality mbLoc
     <+> "Hint"
     <+> renderGallina def
     <+> ":"
@@ -841,14 +841,13 @@ instance Gallina OptionValue where
 
 instance Gallina Option where
   renderGallina' _ (SetOption mbLoc name Nothing)
-    = maybe "" renderGallina mbLoc <+> "Set" <+> text name <> "."
-  renderGallina' _ (SetOption mbLoc name (Just opt)) = maybe "" renderGallina
-    mbLoc
+    = renderFullLocality mbLoc <+> "Set" <+> text name <> "."
+  renderGallina' _ (SetOption mbLoc name (Just opt)) = renderFullLocality mbLoc
     <+> "Set"
     <+> text name
     <+> renderGallina opt <> "."
   renderGallina' _ (UnsetOption mbLoc name)
-    = maybe "" renderGallina mbLoc <+> "Unset" <+> text name <> "."
+    = renderFullLocality mbLoc <+> "Unset" <+> text name <> "."
 
 instance Gallina LocalModule where
   renderGallina' _ (LocalModule name sentences) = vcat

--- a/src/lib/Language/Coq/Pretty.hs
+++ b/src/lib/Language/Coq/Pretty.hs
@@ -837,7 +837,7 @@ instance Gallina Hint where
 
 instance Gallina OptionValue where
   renderGallina' _ (OVNum n)  = renderNum n
-  renderGallina' _ (OVText t) = text t
+  renderGallina' _ (OVText t) = dquotes $ text t
 
 instance Gallina Option where
   renderGallina' _ (SetOption name Nothing)    = "Set" <+> text name <> "."

--- a/src/lib/Language/Coq/Subst.hs
+++ b/src/lib/Language/Coq/Subst.hs
@@ -84,6 +84,8 @@ instance Subst Sentence where
   subst _ s@(ExistingClassSentence _)   = s
   subst _ s@(ArgumentsSentence _)       = s
   subst _ s@(CommentSentence _)         = s
+  subst _ s@(HintSentence _)            = s
+  subst _ s@(OptionSentence _)          = s
 
 instance Subst Assumption where
   subst f (Assumption kwd assumptions) =


### PR DESCRIPTION
<!--
  Have you read our Code of Conduct?
  By filing an issue or pull request, you are expected to comply with it, including treating everyone with respect:
  https://github.com/FreeProving/guidelines/blob/main/CODE_OF_CONDUCT.md
-->

### Issue

closes #7
closes #8

### Description of the Change

The [hint](https://coq.inria.fr/refman/proof-engine/tactics.html?highlight=hint#grammar-token-hint-definition) sentences and [option](https://coq.inria.fr/refman/language/core/basic.html?highlight=set#flags-options-and-tables) sentences have been added to the AST and new `Gallina` instances have been defined for the new data types.

The version has been incremented.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--
  What process did you follow to verify that your change has the desired effects and has not introduced any regressions?
  Describe the actions you performed (including input you checked, tests you created, commands you ran, etc.), and describe the results you observed.
-->

### Additional Notes

<!-- Is there anything else worth mentioning (e.g. changes by your PR that other contributors have to be aware of, ideas for further enhancements, etc.)? -->
